### PR TITLE
work with DS.manyArray

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
 
-var syncForEach = function(array, callback, force, index){
+var syncForEach = function(enumerable, callback, force, index){
   index = Ember.typeOf(index) === 'undefined' ? 0 : index;
   force = Ember.typeOf(force) === 'undefined' ? false : force;
+
+  var array = enumerable.get('content') || enumerable;
 
   return new Ember.RSVP.Promise(function(resolve, reject) {
     if (index < array.length) {
@@ -13,21 +15,21 @@ var syncForEach = function(array, callback, force, index){
 
         if (force) {
           result.then(null,reject).finally(function() {
-            syncForEach(array, callback, force, ++index).then(resolve, reject);
+            syncForEach(enumerable, callback, force, ++index).then(resolve, reject);
           });
         } else {
           result.then( function() {
-            syncForEach(array, callback, force, ++index).then(resolve, reject);
+            syncForEach(enumerable, callback, force, ++index).then(resolve, reject);
           }, reject);
         }
       } else {
 
-        syncForEach(array, callback,force,  ++index).then(resolve, reject);
+        syncForEach(enumerable, callback,force,  ++index).then(resolve, reject);
       }
 
     } else {
 
-      resolve(array);
+      resolve(enumerable);
     }
   });
 };

--- a/tests/unit/sync-for-each-test.js
+++ b/tests/unit/sync-for-each-test.js
@@ -51,13 +51,32 @@ test('it returns a promise which resolves, given an empty array', function(asser
   });
 });
 
-test('it resolves with the input array', function(assert) {
-  assert.expect(1);
+test('it works with array', function(assert) {
+  assert.expect(2);
 
-  syncForEach(array, function() {
+  var testArray = [];
+
+  syncForEach(array, function(item) {
+    testArray.push(item);
     return Ember.RSVP.Promise.resolve();
   }).then(function(result) {
-    assert.equal(result, array);
+    assert.equal(result, array, 'returns the input array');
+    assert.deepEqual(testArray, array, 'executes in correct order');
+  });
+});
+
+test('it works with DS.ManyArray', function(assert) {
+  assert.expect(2);
+
+  var manyArray = DS.ManyArray.create({content: array});
+  var testArray = [];
+
+  syncForEach(manyArray, function(item) {
+    testArray.push(item);
+    return Ember.RSVP.Promise.resolve();
+  }).then(function(result) {
+    assert.equal(result, manyArray, 'returns the input array');
+    assert.deepEqual(testArray, array, 'executes in correct order');
   });
 });
 


### PR DESCRIPTION
This PR makes `syncForEach` aware of `DS.manyArray`s. It will iterate over them as if they were genuine arrays but still resolves with the actual `DS.manyArray` object.

addresses: #1 
